### PR TITLE
Cache all posts, images and other URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+gem 'github-pages'
 
-gem 'github-pages', versions['github-pages']
+group 'jekyll-plugins' do
+  gem 'jekyll-offline', :git => 'git://github.com/jeremiak/jekyll-offline.git'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
-PATH
-  remote: ~/Developer/code/jekyll-offline
+GIT
+  remote: git://github.com/jeremiak/jekyll-offline.git
+  revision: 123867f9d39705250d5d0559cacd02129971f61f
   specs:
     jekyll-offline (0.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,8 @@
+PATH
+  remote: ~/Developer/code/jekyll-offline
+  specs:
+    jekyll-offline (0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -127,8 +132,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 67)
-  json
+  github-pages
+  jekyll-offline!
 
 BUNDLED WITH
    1.10.3

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ ratingscale:
 
 destination: _public
 
+gems: ['jekyll-offline']
+
 # Build settings
 markdown: kramdown
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,8 @@
 
     {% include footer.html %}
 
+    {% register_service_worker %}
+
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Use the [`jekyll-offline`](https://github.com/jeremiak/jekyll-offline) plugin to add a serviceWorker and cache all posts, images, and a few other URLs for offline access.

This is kind of moot because a service worker is required to be served over HTTPS, but since this site is currently hosted on Github pages and uses a custom domain it won't work for now. But I wanted to try out my new plugin
